### PR TITLE
Cyclic dependency in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
     # Runtime dependencies
     install_requires=[
         "colorama>=0.3",
-        "typesentry==" + version,
     ],
     tests_require=[
         "pytest>=3.0",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,13 @@ Build script for the `typesentry` module.
 
 """
 from setuptools import find_packages, setup
-from typesentry.__version__ import version
+
+
+
+with open("typesentry/__version__.py") as fp:
+    version = {}
+    exec(fp.read(), version)
+    version = version['version']
 
 packages = find_packages(exclude=["tests*", "docs*"])
 


### PR DESCRIPTION
Hello I came here because I have a problem using `poetry add` with a package that depends on typesentry. Read details [here](https://github.com/python-poetry/poetry/issues/1985).

It turned out that there were 2 problems:

1.  typesentry has itself in `install_requires` which is easy to fix.
2. `__version__` is loaded in a way that triggers `__init__` which depends on `colorama` package which is not available at the time of installation. i.e. `pip install .` is not working in a clear env, because you have to have `colorama` for it to work. This is not how it is supposed to be.

I changed the way version is loaded into `setup.py` so that `__init__.py` is not triggered, using guidelines from [here](https://packaging.python.org/guides/single-sourcing-package-version/). You may want to use different approach, but this was my take on it, I think it was the easiest one.

Hope this will solve this issue.